### PR TITLE
Sequential numbering for 0012, 0025, and 0030

### DIFF
--- a/0008-unify-pulse-commands-and-instructions.md
+++ b/0008-unify-pulse-commands-and-instructions.md
@@ -2,7 +2,7 @@
 
 | **Status**        | **Proposed**             |
 |:------------------|:---------------------------------------------|
-| **RFC #**         | 0012                                         |
+| **RFC #**         | 0008                                         |
 | **Authors**       | Thomas Alexander (talexander@ibm.com)        |
 | **Deprecates**    | None                                         |
 | **Submitted**     | 2020-02-04                                   |

--- a/0009-interface-for-circuit-operations.md
+++ b/0009-interface-for-circuit-operations.md
@@ -2,7 +2,7 @@
 
 | **Status**        | **Proposed**                                 |
 |:------------------|:---------------------------------------------|
-| **RFC #**         | ####                                         |
+| **RFC #**         | 0009                                         |
 | **Authors**       | Jake Lishman (jake.lishman@ibm.com)          |
 | **Deprecates**    | None                                         |
 | **Submitted**     | 2022-05-31                                   |

--- a/0010-simple-classical-representations.md
+++ b/0010-simple-classical-representations.md
@@ -2,7 +2,7 @@
 
 | **Status**        | **Accepted** |
 |:------------------|:---------------------------------------------|
-| **RFC #**         |  30                                        |
+| **RFC #**         |  10                                        |
 | **Authors**       | Jake Lishman (jake.lishman@ibm.com)          |
 | **Deprecates**    | None                                         |
 | **Submitted**     | 2023-03-15                                   |


### PR DESCRIPTION
The RFC process defines a sequential numbering. So:
- renamed:    0012-unify-pulse-commands-and-instructions.md -> 0008-unify-pulse-commands-and-instructions.md
- renamed:    0025-interface-for-circuit-operations.md -> 0009-interface-for-circuit-operations.md
- renamed:    0030-simple-classical-representations.md -> 0010-simple-classical-representations.md